### PR TITLE
Add support for a join Semilattice

### DIFF
--- a/examples/set_join_semilattice.rs
+++ b/examples/set_join_semilattice.rs
@@ -1,0 +1,47 @@
+use noether::{AssociativeJoin, CommutativeJoin, Join, JoinSemiLattice};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetJoinSemilattice<T: Eq + std::hash::Hash + Clone> {
+    set: HashSet<T>,
+}
+impl<T: Eq + std::hash::Hash + Clone> SetJoinSemilattice<T> {
+    pub const fn new(set: HashSet<T>) -> Self {
+        Self { set }
+    }
+}
+impl<T: Eq + std::hash::Hash + Clone> CommutativeJoin for SetJoinSemilattice<T> {}
+impl<T: Eq + std::hash::Hash + Clone> AssociativeJoin for SetJoinSemilattice<T> {}
+
+impl<T: Eq + std::hash::Hash + Clone> Join for SetJoinSemilattice<T> {
+    fn join(self, other: &Self) -> Self {
+        let union: HashSet<T> = self.set.union(&other.set).cloned().collect();
+        Self { set: union }
+    }
+}
+
+// // impl Join for  {};
+
+impl<T: Eq + std::hash::Hash + Clone> JoinSemiLattice for SetJoinSemilattice<T> {}
+
+fn main() {
+    let set_a: HashSet<_> = vec![1, 2, 3].into_iter().collect();
+    let set_b: HashSet<_> = vec![3, 4, 5].into_iter().collect();
+
+    // Create SetJoinSemilattice elements
+    let semilattice_a = SetJoinSemilattice { set: set_a };
+    let semilattice_b = SetJoinSemilattice { set: set_b };
+
+    // Perform the join operation (union)
+    let result: SetJoinSemilattice<i32> = semilattice_a.join(&semilattice_b);
+    println!("Resulting Set: {:?}", result.set);
+
+    let set_c: HashSet<_> = vec![1, 2, 3].into_iter().collect();
+    let set_d: HashSet<_> = vec![1, 2, 3].into_iter().collect();
+
+    let semilattice_c = SetJoinSemilattice { set: set_c };
+    let semilattice_d = SetJoinSemilattice { set: set_d };
+
+    let result_same_set: SetJoinSemilattice<i32> = semilattice_c.join(&semilattice_d);
+    println!("Resulting Same Set: {:?}", result_same_set.set);
+}

--- a/examples/set_join_semilattice.rs
+++ b/examples/set_join_semilattice.rs
@@ -35,16 +35,18 @@ impl<T: Eq + std::hash::Hash + Clone> Join for SetJoinSemilattice<T> {
 impl<T: Eq + std::hash::Hash + Clone> JoinSemiLattice for SetJoinSemilattice<T> {}
 
 fn main() {
+    // Test 1: check join of different sets
     let set_a: HashSet<_> = vec![1, 2, 3].into_iter().collect();
     let set_b: HashSet<_> = vec![3, 4, 5].into_iter().collect();
 
-    // Create SetJoinSemilattice elements
     let semilattice_a = SetJoinSemilattice { set: set_a };
     let semilattice_b = SetJoinSemilattice { set: set_b };
 
     // Perform the join operation (union)
     let result: SetJoinSemilattice<i32> = semilattice_a.join(&semilattice_b);
     println!("Resulting Set: {:?}", result.set);
+
+    // Test 2: check join of same element
 
     let set_c: HashSet<_> = vec![1, 2, 3].into_iter().collect();
     let set_d: HashSet<_> = vec![1, 2, 3].into_iter().collect();
@@ -54,4 +56,17 @@ fn main() {
 
     let result_same_set: SetJoinSemilattice<i32> = semilattice_c.join(&semilattice_d);
     println!("Resulting Same Set: {:?}", result_same_set.set);
+
+    // Test 2: check join with identity element should return identity
+
+    let set_e: HashSet<_> = vec![1, 2, 4].into_iter().collect();
+
+    let semilattice_e = SetJoinSemilattice { set: set_e };
+    let identity = semilattice_e.identity();
+
+    let result_identity: SetJoinSemilattice<i32> = semilattice_e.join(&identity);
+    println!(
+        "Resulting of join with identity should return same set {:?}",
+        result_identity.set
+    );
 }

--- a/examples/set_join_semilattice.rs
+++ b/examples/set_join_semilattice.rs
@@ -1,4 +1,4 @@
-use noether::{AssociativeJoin, CommutativeJoin, Join, JoinSemiLattice};
+use noether::{AssociativeJoin, CommutativeJoin, IdempotentJoin, Join, JoinSemiLattice};
 use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,10 +13,20 @@ impl<T: Eq + std::hash::Hash + Clone> SetJoinSemilattice<T> {
 impl<T: Eq + std::hash::Hash + Clone> CommutativeJoin for SetJoinSemilattice<T> {}
 impl<T: Eq + std::hash::Hash + Clone> AssociativeJoin for SetJoinSemilattice<T> {}
 
+impl<T: Eq + std::hash::Hash + Clone> IdempotentJoin for SetJoinSemilattice<T> {}
+
 impl<T: Eq + std::hash::Hash + Clone> Join for SetJoinSemilattice<T> {
     fn join(self, other: &Self) -> Self {
         let union: HashSet<T> = self.set.union(&other.set).cloned().collect();
         Self { set: union }
+    }
+
+    /// The identity element: an empty set.
+    /// Satisfies: a ⋁ {} == a
+    fn identity(&self) -> Self {
+        Self {
+            set: HashSet::new(),
+        }
     }
 }
 

--- a/examples/set_join_semilattice.rs
+++ b/examples/set_join_semilattice.rs
@@ -57,7 +57,7 @@ fn main() {
     let result_same_set: SetJoinSemilattice<i32> = semilattice_c.join(&semilattice_d);
     println!("Resulting Same Set: {:?}", result_same_set.set);
 
-    // Test 2: check join with identity element should return identity
+    // Test 3: check join with identity element should return the same set
 
     let set_e: HashSet<_> = vec![1, 2, 4].into_iter().collect();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,16 +612,26 @@ impl<T: Field + PartialOrd> OrderedField for T {}
 /// - For all a, b, c in the semilattice:
 ///   (a ⋁ b) ⋁ c == a ⋁ (b ⋁ c)
 /// This property guarantees that grouping does not affect the result of joins.
-pub trait AssociativeJoin {}
+pub trait IdempotentJoin {}
 /// Ensures that the join operation satisfies commutativity:
 /// - For all a, b in the semilattice:
 ///   a ⋁ b == b ⋁ a
 /// This property allows the order of operands to be swapped without affecting the result.
 
+/// Ensures that the join operation satisfies idempotency:
+/// - For all a in the semilattice:
+///   a ⋁ a == a
+/// This property means that joining an element with itself does not change the element.
+
+pub trait AssociativeJoin {}
+
 pub trait CommutativeJoin {}
 
-pub trait Join: AssociativeJoin + CommutativeJoin {
+pub trait Join: AssociativeJoin + CommutativeJoin + IdempotentJoin {
     fn join(self, other: &Self) -> Self;
+    /// Returns the identity element of the semilattice.
+    /// The identity must satisfy: a ⋁ e == a, where e is the identity element.
+    fn identity(&self) -> Self;
 }
 
 pub trait JoinSemiLattice: Join {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,25 @@ impl<T: EuclideanDomain + MultiplicativeAbelianGroup> Field for T {}
 // OrderedField
 impl<T: Field + PartialOrd> OrderedField for T {}
 
+// properties of Join in a semilattice
+/// Ensures that the join operation satisfies associativity:
+/// - For all a, b, c in the semilattice:
+///   (a ⋁ b) ⋁ c == a ⋁ (b ⋁ c)
+/// This property guarantees that grouping does not affect the result of joins.
+pub trait AssociativeJoin {}
+/// Ensures that the join operation satisfies commutativity:
+/// - For all a, b in the semilattice:
+///   a ⋁ b == b ⋁ a
+/// This property allows the order of operands to be swapped without affecting the result.
+
+pub trait CommutativeJoin {}
+
+pub trait Join: AssociativeJoin + CommutativeJoin {
+    fn join(self, other: &Self) -> Self;
+}
+
+pub trait JoinSemiLattice: Join {}
+
 // RealField
 // Note: This cannot be implemented as a blanket impl because it requires knowledge about completeness
 


### PR DESCRIPTION
Currently supports following properties:
- associativity
- commutativity
- identity

Implemented an example with tests. This example implements a set (which uses union). 

Future improvements:
This example could be extended in the future to implement a merge semilattice, which uses intersection for the join. And combine them into a full lattice